### PR TITLE
Add support for a layered Spring Boot jar

### DIFF
--- a/springboot/default_slicer.go
+++ b/springboot/default_slicer.go
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2018-2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package springboot
+
+import (
+	"github.com/cloudfoundry/libcfbuildpack/v2/layers"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+type DefaultSlicer struct {
+	applicationRoot string
+	metadata        Metadata
+}
+
+func (s DefaultSlicer) Slice() (layers.Slices, error) {
+	var app, dep, launch, snap, rem layers.Slice
+
+	if err := filepath.Walk(s.applicationRoot, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+
+		if info.IsDir() {
+			return nil
+		}
+
+		rel, err := filepath.Rel(s.applicationRoot, path)
+		if err != nil {
+			return err
+		}
+
+		if s.isApplicationSlice(rel) {
+			app.Paths = append(app.Paths, rel)
+		} else if s.isDependencySlice(rel) {
+			dep.Paths = append(dep.Paths, rel)
+		} else if s.isLaunchSlice(rel) {
+			launch.Paths = append(launch.Paths, rel)
+		} else if s.isSnapshotSlice(rel) {
+			snap.Paths = append(snap.Paths, rel)
+		} else {
+			rem.Paths = append(rem.Paths, rel)
+		}
+
+		return nil
+	}); err != nil {
+		return layers.Slices{}, err
+	}
+
+	return layers.Slices{launch, dep, snap, app, rem}, nil // intentionally ordered
+}
+
+func (s DefaultSlicer) isApplicationSlice(path string) bool {
+	return strings.HasPrefix(path, s.metadata.Classes)
+}
+
+func (s DefaultSlicer) isDependencySlice(path string) bool {
+	return strings.HasPrefix(path, s.metadata.Lib) && filepath.Ext(path) == ".jar" && !strings.Contains(path, "SNAPSHOT")
+}
+
+func (s DefaultSlicer) isLaunchSlice(path string) bool {
+	return !strings.HasPrefix(path, s.metadata.Classes) && !strings.HasPrefix(path, s.metadata.Lib) && !strings.HasPrefix(path, "META-INF/")
+}
+
+func (s DefaultSlicer) isSnapshotSlice(path string) bool {
+	return strings.HasPrefix(path, s.metadata.Lib) && filepath.Ext(path) == ".jar" && strings.Contains(path, "SNAPSHOT")
+}
+
+func NewDefaultSlicer(applicationRoot string, metadata Metadata) DefaultSlicer {
+	return DefaultSlicer{
+		applicationRoot,
+		metadata,
+	}
+}

--- a/springboot/default_slicer_test.go
+++ b/springboot/default_slicer_test.go
@@ -1,0 +1,148 @@
+/*
+ * Copyright 2018-2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package springboot_test
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/cloudfoundry/libcfbuildpack/v2/layers"
+	"github.com/cloudfoundry/libcfbuildpack/v2/test"
+	"github.com/cloudfoundry/spring-boot-cnb/springboot"
+	"github.com/onsi/gomega"
+	"github.com/sclevine/spec"
+	"github.com/sclevine/spec/report"
+)
+
+func TestDefaultSlicer(t *testing.T) {
+	spec.Run(t, "DefaultSlicer", func(t *testing.T, when spec.G, it spec.S) {
+
+		g := gomega.NewWithT(t)
+
+		var f *test.BuildFactory
+
+		it.Before(func() {
+			f = test.NewBuildFactory(t)
+		})
+
+		when("Slice", func() {
+
+			var (
+				slices layers.Slices
+				s      springboot.DefaultSlicer
+			)
+
+			it.Before(func() {
+				test.WriteFile(t, filepath.Join(f.Build.Application.Root, "META-INF", "MANIFEST.MF"),
+					`
+Spring-Boot-Classes: test-classes
+Spring-Boot-Lib: test-lib
+Start-Class: test-start-class
+Spring-Boot-Version: test-version`)
+
+				md, ok, err := springboot.NewMetadata(f.Build.Application, f.Build.Logger)
+				g.Expect(ok).To(gomega.BeTrue())
+				g.Expect(err).NotTo(gomega.HaveOccurred())
+
+				e := springboot.NewDefaultSlicer(f.Build.Application.Root, md)
+
+				s = e
+			})
+
+			it("adds application files to slice", func() {
+				test.TouchFile(t, f.Build.Application.Root, "test-classes", "org", "cloudfoundry", "Test.class")
+
+				slices = layers.Slices{
+					{},
+					{},
+					{},
+					{Paths: []string{"test-classes/org/cloudfoundry/Test.class"}},
+					{Paths: []string{"META-INF/MANIFEST.MF"}},
+				}
+
+				result, err := s.Slice()
+				g.Expect(err).NotTo(gomega.HaveOccurred())
+				g.Expect(result).To(gomega.Equal(slices))
+			})
+
+			it("adds dependency files to slice", func() {
+				test.TouchFile(t, f.Build.Application.Root, "test-lib", "test-1.2.3.jar")
+
+				slices = layers.Slices{
+					{},
+					{Paths: []string{"test-lib/test-1.2.3.jar"}},
+					{},
+					{},
+					{Paths: []string{"META-INF/MANIFEST.MF"}},
+				}
+
+				result, err := s.Slice()
+				g.Expect(err).NotTo(gomega.HaveOccurred())
+				g.Expect(result).To(gomega.Equal(slices))
+			})
+
+			it("adds launch files to slice", func() {
+				test.TouchFile(t, f.Build.Application.Root, "org", "cloudfoundry", "Test.class")
+
+				slices = layers.Slices{
+					{Paths: []string{"org/cloudfoundry/Test.class"}},
+					{},
+					{},
+					{},
+					{Paths: []string{"META-INF/MANIFEST.MF"}},
+				}
+
+				result, err := s.Slice()
+				g.Expect(err).NotTo(gomega.HaveOccurred())
+				g.Expect(result).To(gomega.Equal(slices))
+			})
+
+			it("adds snapshot files to slice", func() {
+				test.TouchFile(t, f.Build.Application.Root, "test-lib", "test-1.2.3-SNAPSHOT.jar")
+
+				slices = layers.Slices{
+					{},
+					{},
+					{Paths: []string{"test-lib/test-1.2.3-SNAPSHOT.jar"}},
+					{},
+					{Paths: []string{"META-INF/MANIFEST.MF"}},
+				}
+
+				result, err := s.Slice()
+				g.Expect(err).NotTo(gomega.HaveOccurred())
+				g.Expect(result).To(gomega.Equal(slices))
+			})
+
+			it("adds remainder files to slice", func() {
+				test.TouchFile(t, f.Build.Application.Root, "META-INF", "test-file")
+
+				slices = layers.Slices{
+					{},
+					{},
+					{},
+					{},
+					{Paths: []string{"META-INF/MANIFEST.MF", "META-INF/test-file"}},
+				}
+
+				result, err := s.Slice()
+				g.Expect(err).NotTo(gomega.HaveOccurred())
+				g.Expect(result).To(gomega.Equal(slices))
+			})
+		})
+
+	}, spec.Report(report.Terminal{}))
+}

--- a/springboot/layers_index.go
+++ b/springboot/layers_index.go
@@ -1,0 +1,122 @@
+/*
+ * Copyright 2018-2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package springboot
+
+import (
+	"bufio"
+	"os"
+	"path/filepath"
+	"regexp"
+)
+
+type LayersIndex struct {
+	applicationRoot string
+	layersIndexFile string
+
+	layersIndexDir   string
+	defaultLayerName string
+
+	layerPathRegex *regexp.Regexp
+}
+
+func (l LayersIndex) layerNames() ([]string, error) {
+	if l.layersIndexFile == "" {
+		return nil, nil
+	}
+
+	layerNames, err := readFileLines(filepath.Join(l.applicationRoot, l.layersIndexFile))
+	if err != nil {
+		return nil, err
+	}
+
+	if !sliceContains(layerNames, l.defaultLayerName) {
+		layerNames = append(layerNames, l.defaultLayerName)
+	}
+
+	return layerNames, nil
+}
+
+func (l LayersIndex) layerClassPaths() ([]string, error) {
+	if l.layersIndexFile == "" {
+		return nil, nil
+	}
+
+	layerNames, err := l.layerNames()
+	if err != nil {
+		return nil, err
+	}
+
+	var layerPaths []string
+	for _, layerName := range layerNames {
+		layerPaths = append(layerPaths, filepath.Join(l.applicationRoot, l.layersIndexDir, "layers", layerName, "classes"))
+	}
+
+	return layerPaths, nil
+}
+
+func (l LayersIndex) layerNameForPath(path string, layerNames []string) string {
+	matches := l.layerPathRegex.FindStringSubmatch(path)
+	if len(matches) > 1 {
+		layerName := matches[1]
+		if sliceContains(layerNames, layerName) {
+			return layerName
+		}
+	}
+	return l.defaultLayerName
+}
+
+func readFileLines(path string) ([]string, error) {
+	file, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer file.Close()
+
+	var layerNames []string
+	scanner := bufio.NewScanner(file)
+	for scanner.Scan() {
+		text := scanner.Text()
+		if text != "" {
+			layerNames = append(layerNames, text)
+		}
+	}
+	if scanner.Err() != nil {
+		return nil, scanner.Err()
+	}
+	return layerNames, nil
+}
+
+func sliceContains(s []string, val string) (ok bool) {
+	for i := range s {
+		if ok = s[i] == val; ok {
+			return
+		}
+	}
+	return
+}
+
+func NewLayersIndex(applicationRoot string, layersIndexFile string) LayersIndex {
+	layersIndexDir, _ := filepath.Split(layersIndexFile)
+
+	return LayersIndex{
+		applicationRoot,
+		layersIndexFile,
+		layersIndexDir,
+		"application",
+		regexp.MustCompile(`^` + layersIndexDir + `layers/([a-zA-Z0-9-]+)/.*$`),
+	}
+}

--- a/springboot/layers_index_slicer.go
+++ b/springboot/layers_index_slicer.go
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2018-2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package springboot
+
+import (
+	"github.com/cloudfoundry/libcfbuildpack/v2/layers"
+	"os"
+	"path/filepath"
+)
+
+type LayersIndexSlicer struct {
+	applicationRoot string
+	layersIndex     LayersIndex
+}
+
+func (s LayersIndexSlicer) Slice() (layers.Slices, error) {
+	layerNames, err := s.layersIndex.layerNames()
+	if err != nil {
+		return layers.Slices{}, err
+	}
+
+	slicesByLayerName := make(map[string]layers.Slice)
+
+	if err := filepath.Walk(s.applicationRoot, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+
+		if info.IsDir() {
+			return nil
+		}
+
+		rel, err := filepath.Rel(s.applicationRoot, path)
+		if err != nil {
+			return err
+		}
+
+		layerName := s.layersIndex.layerNameForPath(rel, layerNames)
+		layer, exists := slicesByLayerName[layerName]
+		if !exists {
+			layer = layers.Slice{}
+		}
+		layer.Paths = append(layer.Paths, rel)
+		slicesByLayerName[layerName] = layer
+
+		return nil
+	}); err != nil {
+		return layers.Slices{}, err
+	}
+
+	var result []layers.Slice
+	for _, layerName := range layerNames {
+		result = append(result, slicesByLayerName[layerName])
+	}
+	return result, nil
+}
+
+func NewLayersIndexSlicer(applicationRoot string, layersIndex string) LayersIndexSlicer {
+	return LayersIndexSlicer{
+		applicationRoot,
+		NewLayersIndex(applicationRoot, layersIndex),
+	}
+}

--- a/springboot/layers_index_slicer_test.go
+++ b/springboot/layers_index_slicer_test.go
@@ -1,0 +1,123 @@
+/*
+ * Copyright 2018-2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package springboot_test
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/cloudfoundry/libcfbuildpack/v2/layers"
+	"github.com/cloudfoundry/libcfbuildpack/v2/test"
+	"github.com/cloudfoundry/spring-boot-cnb/springboot"
+	"github.com/onsi/gomega"
+	"github.com/sclevine/spec"
+	"github.com/sclevine/spec/report"
+)
+
+func TestLayersIndexSlicer(t *testing.T) {
+	spec.Run(t, "LayersIndexSlicer", func(t *testing.T, when spec.G, it spec.S) {
+
+		g := gomega.NewWithT(t)
+
+		var f *test.BuildFactory
+
+		it.Before(func() {
+			f = test.NewBuildFactory(t)
+		})
+
+		when("Slice", func() {
+
+			var (
+				slices layers.Slices
+				s      springboot.LayersIndexSlicer
+			)
+
+			it.Before(func() {
+				test.WriteFile(t, filepath.Join(f.Build.Application.Root, "META-INF", "MANIFEST.MF"),
+					`
+Spring-Boot-Version: test-version
+Spring-Boot-Layers-Index: test-inf/layers.idx`)
+
+				e := springboot.NewLayersIndexSlicer(f.Build.Application.Root, "test-inf/layers.idx")
+
+				s = e
+			})
+
+			it("returns error if Layers-Index not found", func() {
+				_, err := s.Slice()
+				g.Expect(err).To(gomega.HaveOccurred())
+			})
+
+			it("adds layers from index to slices with application default", func() {
+				test.WriteFile(t, filepath.Join(f.Build.Application.Root, "test-inf", "layers.idx"),
+					`dependencies
+application
+resources`)
+				test.TouchFile(t, f.Build.Application.Root, "org", "cloudfoundry", "Test.class")
+				test.TouchFile(t, f.Build.Application.Root, "test-inf", "layers", "application", "org", "cloudfoundry", "TestApplication.class")
+				test.TouchFile(t, f.Build.Application.Root, "test-inf", "layers", "unknown", "org", "cloudfoundry", "TestUnknown.class")
+				test.TouchFile(t, f.Build.Application.Root, "test-inf", "layers", "resources", "static", "index.html")
+				test.TouchFile(t, f.Build.Application.Root, "test-inf", "layers", "dependencies", "lib", "released-1.2.3.jar")
+
+				slices = layers.Slices{
+					{Paths: []string{"test-inf/layers/dependencies/lib/released-1.2.3.jar"}},
+					{Paths: []string{
+						"META-INF/MANIFEST.MF",
+						"org/cloudfoundry/Test.class",
+						"test-inf/layers/application/org/cloudfoundry/TestApplication.class",
+						"test-inf/layers/unknown/org/cloudfoundry/TestUnknown.class",
+						"test-inf/layers.idx",
+					}},
+					{Paths: []string{"test-inf/layers/resources/static/index.html"}},
+				}
+
+				result, err := s.Slice()
+				g.Expect(err).NotTo(gomega.HaveOccurred())
+				g.Expect(result).To(gomega.Equal(slices))
+			})
+
+			it("adds layers from index to slices without application default", func() {
+				test.WriteFile(t, filepath.Join(f.Build.Application.Root, "test-inf", "layers.idx"),
+					`dependencies
+classes`)
+				test.TouchFile(t, f.Build.Application.Root, "org", "cloudfoundry", "Test.class")
+				test.TouchFile(t, f.Build.Application.Root, "test-inf", "layers", "classes", "org", "cloudfoundry", "TestApplication.class")
+				test.TouchFile(t, f.Build.Application.Root, "test-inf", "layers", "unknown", "org", "cloudfoundry", "TestUnknown.class")
+				test.TouchFile(t, f.Build.Application.Root, "test-inf", "layers", "dependencies", "lib", "released-1.2.3.jar")
+
+				slices = layers.Slices{
+					{Paths: []string{"test-inf/layers/dependencies/lib/released-1.2.3.jar"}},
+					{Paths: []string{
+						"test-inf/layers/classes/org/cloudfoundry/TestApplication.class",
+					}},
+					{Paths: []string{
+						"META-INF/MANIFEST.MF",
+						"org/cloudfoundry/Test.class",
+						"test-inf/layers/unknown/org/cloudfoundry/TestUnknown.class",
+						"test-inf/layers.idx",
+					}},
+				}
+
+				result, err := s.Slice()
+				g.Expect(err).NotTo(gomega.HaveOccurred())
+				g.Expect(result).To(gomega.Equal(slices))
+			})
+
+		})
+
+	}, spec.Report(report.Terminal{}))
+}

--- a/springboot/spring_boot_test.go
+++ b/springboot/spring_boot_test.go
@@ -65,113 +65,6 @@ Spring-Boot-Version: test-version`)
 			})
 		})
 
-		when("Slices", func() {
-
-			var (
-				metadata layers.Metadata
-				s        springboot.SpringBoot
-			)
-
-			it.Before(func() {
-				test.WriteFile(t, filepath.Join(f.Build.Application.Root, "META-INF", "MANIFEST.MF"),
-					`
-Spring-Boot-Classes: test-classes
-Spring-Boot-Lib: test-lib
-Start-Class: test-start-class
-Spring-Boot-Version: test-version`)
-
-				e, ok, err := springboot.NewSpringBoot(f.Build)
-				g.Expect(ok).To(gomega.BeTrue())
-				g.Expect(err).NotTo(gomega.HaveOccurred())
-
-				s = e
-
-				command := "java -cp $CLASSPATH $JAVA_OPTS test-start-class"
-				metadata = layers.Metadata{
-					Processes: []layers.Process{
-						{Type: "spring-boot", Command: command},
-						{Type: "task", Command: command},
-						{Type: "web", Command: command},
-					},
-				}
-			})
-
-			it("adds application files to slice", func() {
-				test.TouchFile(t, f.Build.Application.Root, "test-classes", "org", "cloudfoundry", "Test.class")
-
-				metadata.Slices = layers.Slices{
-					{},
-					{},
-					{},
-					{Paths: []string{"test-classes/org/cloudfoundry/Test.class"}},
-					{Paths: []string{"META-INF/MANIFEST.MF"}},
-				}
-
-				g.Expect(s.Contribute()).To(gomega.Succeed())
-				g.Expect(f.Build.Layers).To(test.HaveApplicationMetadata(metadata))
-			})
-
-			it("adds dependency files to slice", func() {
-				test.TouchFile(t, f.Build.Application.Root, "test-lib", "test-1.2.3.jar")
-
-				metadata.Slices = layers.Slices{
-					{},
-					{Paths: []string{"test-lib/test-1.2.3.jar"}},
-					{},
-					{},
-					{Paths: []string{"META-INF/MANIFEST.MF"}},
-				}
-
-				g.Expect(s.Contribute()).To(gomega.Succeed())
-				g.Expect(f.Build.Layers).To(test.HaveApplicationMetadata(metadata))
-			})
-
-			it("adds launch files to slice", func() {
-				test.TouchFile(t, f.Build.Application.Root, "org", "cloudfoundry", "Test.class")
-
-				metadata.Slices = layers.Slices{
-					{Paths: []string{"org/cloudfoundry/Test.class"}},
-					{},
-					{},
-					{},
-					{Paths: []string{"META-INF/MANIFEST.MF"}},
-				}
-
-				g.Expect(s.Contribute()).To(gomega.Succeed())
-				g.Expect(f.Build.Layers).To(test.HaveApplicationMetadata(metadata))
-			})
-
-			it("adds snapshot files to slice", func() {
-				test.TouchFile(t, f.Build.Application.Root, "test-lib", "test-1.2.3-SNAPSHOT.jar")
-
-				metadata.Slices = layers.Slices{
-					{},
-					{},
-					{Paths: []string{"test-lib/test-1.2.3-SNAPSHOT.jar"}},
-					{},
-					{Paths: []string{"META-INF/MANIFEST.MF"}},
-				}
-
-				g.Expect(s.Contribute()).To(gomega.Succeed())
-				g.Expect(f.Build.Layers).To(test.HaveApplicationMetadata(metadata))
-			})
-
-			it("adds remainder files to slice", func() {
-				test.TouchFile(t, f.Build.Application.Root, "META-INF", "test-file")
-
-				metadata.Slices = layers.Slices{
-					{},
-					{},
-					{},
-					{},
-					{Paths: []string{"META-INF/MANIFEST.MF", "META-INF/test-file"}},
-				}
-
-				g.Expect(s.Contribute()).To(gomega.Succeed())
-				g.Expect(f.Build.Layers).To(test.HaveApplicationMetadata(metadata))
-			})
-		})
-
 		it("contributes dependencies to BOM", func() {
 			test.CopyFile(t, filepath.Join("testdata", "test-artifact-1-1.2.3.jar"),
 				filepath.Join(f.Build.Application.Root, "test-lib", "test-artifact-1-1.2.3.jar"))
@@ -214,6 +107,7 @@ Spring-Boot-Version: test-version`)
 							SHA256:  "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
 						},
 					},
+					"layers-index": "",
 				},
 			}))
 		})
@@ -242,6 +136,7 @@ Spring-Boot-Version: test-version`)
 						filepath.Join(f.Build.Application.Root, "test-classes"),
 					},
 					"dependencies": springboot.JARDependencies{},
+					"layers-index": "",
 				},
 			}))
 		})


### PR DESCRIPTION
This buildpack contains internal rules for creating layers for a
Spring Boot application. Starting with version 2.3.0, Spring Boot
will write layering information to jar files generated by its Maven
and Gradle plugins, which might include custom layers configured by
the user. This commit modifies the buildpack to honor the layering
information provided by Spring Boot when it is provided, and falls
back to existing internal rules when not provided.

[resolves #6]

Signed-off-by: Scott Frederick <sfrederick@pivotal.io>